### PR TITLE
Corrija o código

### DIFF
--- a/index.php
+++ b/index.php
@@ -8,6 +8,18 @@ if(is_dir(__DIR__."/install") && !file_exists(__DIR__."/install/.lock"))
 
 /*
  *---------------------------------------------------------------
+ * COMPATIBILITY NOTICE
+ *---------------------------------------------------------------
+ * 
+ * This FusionCMS installation has been updated for modern PHP compatibility:
+ * - Removed deprecated magic_quotes functionality (PHP 5.4+)
+ * - Fixed deprecated each() function usage (PHP 8.0+)
+ * - Added warning for deprecated MySQL driver (use MySQLi/PDO instead)
+ * - Updated error reporting settings
+ * 
+ * For best compatibility, use PHP 7.4+ with MySQLi or PDO database drivers.
+ *
+ *---------------------------------------------------------------
  * APPLICATION ENVIRONMENT
  *---------------------------------------------------------------
  *
@@ -40,7 +52,7 @@ if (defined('ENVIRONMENT'))
 	switch (ENVIRONMENT)
 	{
 		case 'development':
-			error_reporting(E_ALL & ~E_DEPRECATED);
+			error_reporting(E_ALL);
 			ini_set('display_errors', '1');
 		break;
 	
@@ -204,18 +216,8 @@ if(!ini_get('date.timezone'))
 		define('APPPATH', BASEPATH.$application_folder.'/');
 	}
 
-	if(get_magic_quotes_gpc())
-	{
-	    function stripslashes_gpc(&$value)
-	    {
-	        $value = stripslashes($value);
-	    }
-	    
-	    array_walk_recursive($_GET, 'stripslashes_gpc');
-	    array_walk_recursive($_POST, 'stripslashes_gpc');
-	    array_walk_recursive($_COOKIE, 'stripslashes_gpc');
-	    array_walk_recursive($_REQUEST, 'stripslashes_gpc');
-	}
+	// Magic quotes functionality was removed in PHP 5.4
+	// Since magic quotes are deprecated and removed, no action is needed
 	
 /*
  * --------------------------------------------------------------------

--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -74,10 +74,8 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  */
 	set_error_handler('_exception_handler');
 
-	if ( ! is_php('5.4'))
-	{
-		@ini_set('magic_quotes_runtime', 0); // Kill magic quotes
-	}
+	// Magic quotes functionality was removed in PHP 5.4+
+	// No longer need to disable magic_quotes_runtime
 
 /*
  * ------------------------------------------------------

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -674,15 +674,10 @@ class CI_Input {
 			return $new_array;
 		}
 
-		/* We strip slashes if magic quotes is on to keep things consistent
-
-		   NOTE: In PHP 5.4 get_magic_quotes_gpc() will always return 0 and
-			 it will probably not exist in future versions at all.
+		/* Magic quotes functionality was removed in PHP 5.4+
+		   No longer need to strip slashes for magic quotes.
 		*/
-		if ( ! is_php('5.4') && get_magic_quotes_gpc())
-		{
-			$str = stripslashes($str);
-		}
+		// Magic quotes removed - no action needed
 
 		// Clean UTF-8 if supported
 		if (UTF8_ENABLED === TRUE)

--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -269,10 +269,10 @@ class CI_Security {
 		 */
 		if (is_array($str))
 		{
-			while (list($key) = each($str))
-			{
-				$str[$key] = $this->xss_clean($str[$key]);
-			}
+					foreach (array_keys($str) as $key)
+		{
+			$str[$key] = $this->xss_clean($str[$key]);
+		}
 
 			return $str;
 		}

--- a/system/database/drivers/mysql/mysql_driver.php
+++ b/system/database/drivers/mysql/mysql_driver.php
@@ -17,6 +17,10 @@
 
 /**
  * MySQL Database Adapter Class
+ * 
+ * WARNING: This driver uses the deprecated MySQL extension that was removed in PHP 7.0.
+ * For PHP 7.0+ compatibility, please use the MySQLi or PDO drivers instead.
+ * The mysql_* functions used in this driver will not work on PHP 7.0 or newer.
  *
  * Note: _DB is an extender class that the app controller
  * creates dynamically based on whether the active record

--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -382,16 +382,10 @@ class CI_Email {
 	{
 		$this->_body = rtrim(str_replace("\r", "", $body));
 
-		/* strip slashes only if magic quotes is ON
-		   if we do it with magic quotes OFF, it strips real, user-inputted chars.
-
-		   NOTE: In PHP 5.4 get_magic_quotes_gpc() will always return 0 and
-			 it will probably not exist in future versions at all.
+		/* Magic quotes functionality was removed in PHP 5.4+
+		   No longer need to strip slashes for magic quotes.
 		*/
-		if ( ! is_php('5.4') && get_magic_quotes_gpc())
-		{
-			$this->_body = stripslashes($this->_body);
-		}
+		// Magic quotes removed - no action needed
 
 		return $this;
 	}

--- a/system/libraries/Xmlrpc.php
+++ b/system/libraries/Xmlrpc.php
@@ -245,10 +245,10 @@ class CI_Xmlrpc {
 			}
 			elseif (is_array($value['0']) && ($value['1'] == 'struct' OR $value['1'] == 'array'))
 			{
-				while (list($k) = each($value['0']))
-				{
-					$value['0'][$k] = $this->values_parsing($value['0'][$k], TRUE);
-				}
+							foreach (array_keys($value['0']) as $k)
+			{
+				$value['0'][$k] = $this->values_parsing($value['0'][$k], TRUE);
+			}
 
 				$temp = new XML_RPC_Values($value['0'], $value['1']);
 			}


### PR DESCRIPTION
Update FusionCMS for modern PHP compatibility by addressing deprecated functions and improving error reporting.

This PR fixes several PHP compatibility issues in FusionCMS, including the removal of `magic_quotes_gpc` functionality (deprecated in PHP 5.3, removed in 5.4), replacement of the `each()` function (removed in PHP 8.0) with `foreach`, and adding a warning to the `mysql_driver.php` which uses `mysql_*` functions (removed in PHP 7.0). It also updates error reporting for development and adds a general compatibility notice.

---
<a href="https://cursor.com/background-agent?bcId=bc-1424c8b3-1cd9-445a-9dfe-91491f2d0165">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1424c8b3-1cd9-445a-9dfe-91491f2d0165">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>